### PR TITLE
Brand migration: Update org references ambiware-labs → loqalabs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: mailto:security@ambiware.ai
     about: Please report security issues privately.
   - name: Community Discussions
-    url: https://github.com/ambiware-labs/loqa-meta/discussions
+    url: https://github.com/loqalabs/loqa-meta/discussions
     about: Use discussions for questions and open-ended ideas.

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ Documentation in this repository is licensed under the MIT License.
 
 - Website: [ambiware.ai](https://ambiware.ai)
 - Email: hello@ambiware.ai
-- GitHub: [@ambiware-labs](https://github.com/ambiware-labs)
+- GitHub: [@loqalabs](https://github.com/loqalabs)
 - Security disclosures: See [SECURITY.md](SECURITY.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 This policy applies to all Ambiware Labs open-source projects, including but not limited to:
 
-- [`loqa-core`](https://github.com/ambiware-labs/loqa-core)
-- [`loqa-meta`](https://github.com/ambiware-labs/loqa-meta)
-- [`loqa-skills`](https://github.com/ambiware-labs/loqa-skills)
-- [`loqa-site`](https://github.com/ambiware-labs/loqa-site)
+- [`loqa-core`](https://github.com/loqalabs/loqa-core)
+- [`loqa-meta`](https://github.com/loqalabs/loqa-meta)
+- [`loqa-skills`](https://github.com/loqalabs/loqa-skills)
+- [`loqa-site`](https://github.com/loqalabs/loqa-site)
 
 If you are unsure whether an asset is in scope, please contact us first—do not disclose details publicly.
 

--- a/community/README.md
+++ b/community/README.md
@@ -14,7 +14,7 @@ We’re building relationships with privacy-first and hardware-focused partners.
 
 ## GitHub Discussions
 
-Discussions are enabled on both [`loqa-core`](https://github.com/ambiware-labs/loqa-core/discussions) and [`loqa-meta`](https://github.com/ambiware-labs/loqa-meta/discussions). Use the following categories when starting new threads:
+Discussions are enabled on both [`loqa-core`](https://github.com/loqalabs/loqa-core/discussions) and [`loqa-meta`](https://github.com/loqalabs/loqa-meta/discussions). Use the following categories when starting new threads:
 
 - **Announcements** – Core team updates, release notes, roadmap milestones.
 - **Ideas** – Feature proposals, architectural suggestions, and workflow improvements.

--- a/community/contributing-guide.md
+++ b/community/contributing-guide.md
@@ -9,14 +9,14 @@ Welcome! This guide highlights easy ways to get involved, how to find beginner-f
 - Tackle issues labeled `good first issue` or `help wanted` across repositories.
 
 Browse open issues:
-- [`loqa-core` issues](https://github.com/ambiware-labs/loqa-core/issues)
-- [`loqa-site` issues](https://github.com/ambiware-labs/loqa-site/issues)
-- [`loqa-meta` issues](https://github.com/ambiware-labs/loqa-meta/issues)
+- [`loqa-core` issues](https://github.com/loqalabs/loqa-core/issues)
+- [`loqa-site` issues](https://github.com/loqalabs/loqa-site/issues)
+- [`loqa-meta` issues](https://github.com/loqalabs/loqa-meta/issues)
 
 ## Submitting a Skill or Persona
-1. Follow the [Extension Labs templates](extension-labs/README.md) and the [skills spec](https://github.com/ambiware-labs/loqa-core/blob/main/docs/skills/SPEC.md).
+1. Follow the [Extension Labs templates](extension-labs/README.md) and the [skills spec](https://github.com/loqalabs/loqa-core/blob/main/docs/skills/SPEC.md).
 2. Validate your manifest: `go run ./cmd/loqa-skill validate --file skill.yaml`.
-3. Share your work in [Loqa Discussions](https://github.com/ambiware-labs/loqa-core/discussions) under “Show and Tell”.
+3. Share your work in [Loqa Discussions](https://github.com/loqalabs/loqa-core/discussions) under “Show and Tell”.
 4. (Optional) Prepare metadata for the upcoming marketplace (see [studio/README.md](../studio/README.md)).
 
 ## Proposing an RFC
@@ -37,7 +37,7 @@ Browse open issues:
 - [Partner outreach pipeline](../community/outreach/partner_pipeline.md)
 
 ## Questions?
-- Join [GitHub Discussions](https://github.com/ambiware-labs/loqa-meta/discussions).
-- Ping `@ambiware-labs` or email [hello@ambiware.ai](mailto:hello@ambiware.ai).
+- Join [GitHub Discussions](https://github.com/loqalabs/loqa-meta/discussions).
+- Ping `@loqalabs` or email [hello@ambiware.ai](mailto:hello@ambiware.ai).
 
 Thanks for helping shape Loqa—every contribution keeps privacy-focused ambient intelligence in the hands of the community.

--- a/community/extension-labs/README.md
+++ b/community/extension-labs/README.md
@@ -14,24 +14,24 @@ Our goals:
 1. **Fork or template a starter project**
    - [TinyGo WASM template](templates/tinygo-skill-template/README.md)
    - [Exec adapter template](templates/exec-skill-template/README.md)
-2. **Develop locally** using the guidance in [`skills/AUTHORING_GUIDE.md`](https://github.com/ambiware-labs/loqa-core/blob/main/skills/AUTHORING_GUIDE.md) and the formal [`skills spec`](https://github.com/ambiware-labs/loqa-core/blob/main/docs/skills/SPEC.md).
+2. **Develop locally** using the guidance in [`skills/AUTHORING_GUIDE.md`](https://github.com/loqalabs/loqa-core/blob/main/skills/AUTHORING_GUIDE.md) and the formal [`skills spec`](https://github.com/loqalabs/loqa-core/blob/main/docs/skills/SPEC.md).
 3. **Validate your manifest**
    ```bash
    go run ./cmd/loqa-skill validate --file skill.yaml
    ```
 4. **Share your work**
-   - Open a “Show and Tell” thread in [GitHub Discussions](https://github.com/ambiware-labs/loqa-core/discussions).
+   - Open a “Show and Tell” thread in [GitHub Discussions](https://github.com/loqalabs/loqa-core/discussions).
    - Submit a PR to add your template/link to this directory.
-   - Prepare for the marketplace by tracking [RFC-0003](https://github.com/ambiware-labs/loqa-meta/blob/main/rfcs/RFC-0003_loqa_marketplace_mvp.md).
+   - Prepare for the marketplace by tracking [RFC-0003](https://github.com/loqalabs/loqa-meta/blob/main/rfcs/RFC-0003_loqa_marketplace_mvp.md).
 
 ## Contributor Showcase
 
 | Skill | Maintainer | Description | Tags |
 | --- | --- | --- | --- |
-| [timer](https://github.com/ambiware-labs/loqa-core/tree/main/skills/examples/timer) | Ambiware Labs | Simple countdown timer that announces completions. | timers, voice |
-| [smart-home-bridge](https://github.com/ambiware-labs/loqa-core/tree/main/skills/examples/smart-home) | Ambiware Labs | Bridges Loqa intents to Home Assistant. | home-automation, voice |
+| [timer](https://github.com/loqalabs/loqa-core/tree/main/skills/examples/timer) | Ambiware Labs | Simple countdown timer that announces completions. | timers, voice |
+| [smart-home-bridge](https://github.com/loqalabs/loqa-core/tree/main/skills/examples/smart-home) | Ambiware Labs | Bridges Loqa intents to Home Assistant. | home-automation, voice |
 
-> Have a skill to feature? [Open an issue](https://github.com/ambiware-labs/loqa-meta/issues/new?labels=community&title=Showcase%20submission%3A%20%3Cskill%3E) with links and tags.
+> Have a skill to feature? [Open an issue](https://github.com/loqalabs/loqa-meta/issues/new?labels=community&title=Showcase%20submission%3A%20%3Cskill%3E) with links and tags.
 
 ## Templates
 
@@ -51,7 +51,7 @@ Contribute improvements as you discover best practices.
 
 ## Roadmap
 
-- Track open tasks in [loqa-meta#27](https://github.com/ambiware-labs/loqa-meta/issues/27).
+- Track open tasks in [loqa-meta#27](https://github.com/loqalabs/loqa-meta/issues/27).
 - Marketplace submission guide will land after RFC-0003 is accepted.
 - Looking for collaborators? Drop an idea in the Discussions “Ideas” category.
 

--- a/community/extension-labs/templates/exec-skill-template/README.md
+++ b/community/extension-labs/templates/exec-skill-template/README.md
@@ -10,7 +10,7 @@ Template for skills that call an external executable or script instead of WASM m
 ## Usage
 
 ```bash
-git clone https://github.com/ambiware-labs/loqa-core.git skills-lab
+git clone https://github.com/loqalabs/loqa-core.git skills-lab
 cd skills-lab/community/extension-labs/templates/exec-skill-template
 make package
 make validate

--- a/community/extension-labs/templates/tinygo-skill-template/README.md
+++ b/community/extension-labs/templates/tinygo-skill-template/README.md
@@ -3,14 +3,14 @@
 Starter template for building a WASM skill using TinyGo.
 
 ## Contents
-- `skill.yaml` – placeholder manifest aligned with [`docs/skills/SPEC.md`](https://github.com/ambiware-labs/loqa-core/blob/main/docs/skills/SPEC.md)
+- `skill.yaml` – placeholder manifest aligned with [`docs/skills/SPEC.md`](https://github.com/loqalabs/loqa-core/blob/main/docs/skills/SPEC.md)
 - `src/main.go` – basic TinyGo entrypoint using the `host` helper
 - `Makefile` – build + validate targets
 
 ## Usage
 
 ```bash
-git clone https://github.com/ambiware-labs/loqa-core.git skills-lab
+git clone https://github.com/loqalabs/loqa-core.git skills-lab
 cd skills-lab/community/extension-labs/templates/tinygo-skill-template
 make build
 make validate

--- a/community/extension-labs/templates/tinygo-skill-template/src/main.go
+++ b/community/extension-labs/templates/tinygo-skill-template/src/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"syscall"
 
-	"github.com/ambiware-labs/loqa-core/skills/examples/internal/host"
+	"github.com/loqalabs/loqa-core/skills/examples/internal/host"
 )
 
 type request struct {

--- a/community/outreach/partner_pipeline.md
+++ b/community/outreach/partner_pipeline.md
@@ -1,6 +1,6 @@
 # Partner Outreach Pipeline
 
-Issue reference: [loqa-meta#29](https://github.com/ambiware-labs/loqa-meta/issues/29)
+Issue reference: [loqa-meta#29](https://github.com/loqalabs/loqa-meta/issues/29)
 
 ## Objectives
 - Engage hardware vendors, privacy communities, and integrators aligned with Loqa’s values.

--- a/governance/PROJECT_BOARD.md
+++ b/governance/PROJECT_BOARD.md
@@ -35,7 +35,7 @@ Columns are mapped to delivery states:
 - Generate progress reports from board data for monthly updates
 
 ## Links
-- GitHub Project: `https://github.com/orgs/ambiware-labs/projects/1` (create and update URL once live)
+- GitHub Project: `https://github.com/orgs/loqalabs/projects/1` (create and update URL once live)
 - MVP Backlog: [roadmap/MVP_BACKLOG.md](../roadmap/MVP_BACKLOG.md)
 - RFC Index: [rfcs/](../rfcs)
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -109,6 +109,6 @@ This governance model will evolve as the project grows. Changes to governance re
 
 ## Contact
 
-- GitHub: [@ambiware-labs](https://github.com/ambiware-labs)
+- GitHub: [@loqalabs](https://github.com/loqalabs)
 - Email: hello@ambiware.ai
-- Discussions: [GitHub Discussions](https://github.com/ambiware-labs/loqa-meta/discussions)
+- Discussions: [GitHub Discussions](https://github.com/loqalabs/loqa-meta/discussions)

--- a/governance/ambiw_org_setup.md
+++ b/governance/ambiw_org_setup.md
@@ -1,7 +1,7 @@
 # Ambiware Labs Setup Notes
 
 ## Organization
-- **GitHub handle:** `ambiware-labs`
+- **GitHub handle:** `loqalabs`
 - **Display name:** Ambiware Labs
 - **Description:** "Building Loqa: a local-first, open-core ambient intelligence platform."
 - **Website:** https://ambiware.ai
@@ -17,7 +17,7 @@
   - `185.199.109.153`
   - `185.199.110.153`
   - `185.199.111.153`
-- Add `CNAME www → ambiware-labs.github.io`.
+- Add `CNAME www → loqalabs.github.io`.
 - In the Pages repo: add a `CNAME` file with `ambiware.ai`, set the custom domain in GitHub Pages, and enable HTTPS once available.
 
 ### Email (iCloud Custom Domain)

--- a/governance/privacy.md
+++ b/governance/privacy.md
@@ -23,7 +23,7 @@ Loqa is built for local-first, privacy-preserving ambient intelligence. These pr
 
 ## User Agency & Transparency
 - Configuration changes, permissions, and updates are auditable.
-- Skills must declare subjects, permissions, and external calls in their manifest (see [`docs/skills/SPEC.md`](https://github.com/ambiware-labs/loqa-core/blob/main/docs/skills/SPEC.md)).
+- Skills must declare subjects, permissions, and external calls in their manifest (see [`docs/skills/SPEC.md`](https://github.com/loqalabs/loqa-core/blob/main/docs/skills/SPEC.md)).
 - Marketplace submissions undergo safety review to ensure they honour these principles.
 
 ## Incident Response

--- a/rfcs/RFC-0003_loqa_marketplace_mvp.md
+++ b/rfcs/RFC-0003_loqa_marketplace_mvp.md
@@ -4,7 +4,7 @@
 - **Authors:** Anna Barnes, Ambiware Labs Team
 - **Created:** 2025-09-28
 - **Target Release:** Workstream F – Ecosystem Foundations
-- **Discussion:** https://github.com/ambiware-labs/loqa-meta/issues/26
+- **Discussion:** https://github.com/loqalabs/loqa-meta/issues/26
 
 ## Summary
 Establish the first iteration of the Loqa Marketplace: a lightweight distribution channel for skills and adapters that complements the open-core runtime. The MVP will define the package format, metadata requirements, signing model, and the minimal services/CLI needed to discover, install, and update skills while preserving Loqa’s local-first ethos.
@@ -43,7 +43,7 @@ Future phases may introduce a dedicated API or UI, but the MVP relies on static 
     "skills": [
       {
         "name": "timer",
-        "package": "https://github.com/ambiware-labs/loqa-skills/releases/download/v0.1.0/timer-0.1.0.tar.gz",
+        "package": "https://github.com/loqalabs/loqa-skills/releases/download/v0.1.0/timer-0.1.0.tar.gz",
         "manifest": "sha256:...",
         "wasm": "sha256:...",
         "version": "0.1.0",
@@ -120,8 +120,8 @@ Future phases may introduce a dedicated API or UI, but the MVP relies on static 
    - Update authoring guide, site docs, and blog with marketplace instructions.
 
 ## References
-- [Issue #26: Draft marketplace RFC](https://github.com/ambiware-labs/loqa-meta/issues/26)
-- [docs/skills/SPEC.md](https://github.com/ambiware-labs/loqa-core/blob/main/docs/skills/SPEC.md)
-- [loqa-core#37](https://github.com/ambiware-labs/loqa-core/issues/37) – skills spec evolution
+- [Issue #26: Draft marketplace RFC](https://github.com/loqalabs/loqa-meta/issues/26)
+- [docs/skills/SPEC.md](https://github.com/loqalabs/loqa-core/blob/main/docs/skills/SPEC.md)
+- [loqa-core#37](https://github.com/loqalabs/loqa-core/issues/37) – skills spec evolution
 - [Crates.io index design](https://doc.rust-lang.org/cargo/reference/registry-index.html)
 - [VS Code extension marketplace format](https://code.visualstudio.com/api/working-with-extensions/publishing-extension)

--- a/roadmap/MVP_BACKLOG.md
+++ b/roadmap/MVP_BACKLOG.md
@@ -3,18 +3,18 @@
 This backlog tracks the committed work required to reach the MVP milestone (Phase 1 – Foundation).
 
 ## Workstream A: Core Runtime ✅
-- [x] Runtime bootstrap: service container, configuration loader, tracing wiring ([loqa-core#4](https://github.com/ambiware-labs/loqa-core/issues/4))
-- [x] Message bus integration (NATS) with subject catalog ([loqa-core#5](https://github.com/ambiware-labs/loqa-core/issues/5))
-- [x] Capability registry and node heartbeat protocol ([loqa-core#6](https://github.com/ambiware-labs/loqa-core/issues/6))
-- [x] Local event store (SQLite + LiteFS) proof of concept ([loqa-core#7](https://github.com/ambiware-labs/loqa-core/issues/7))
-- [x] Observability stack deployment scripts (Grafana, Tempo, Prometheus) ([loqa-core#8](https://github.com/ambiware-labs/loqa-core/issues/8))
+- [x] Runtime bootstrap: service container, configuration loader, tracing wiring ([loqa-core#4](https://github.com/loqalabs/loqa-core/issues/4))
+- [x] Message bus integration (NATS) with subject catalog ([loqa-core#5](https://github.com/loqalabs/loqa-core/issues/5))
+- [x] Capability registry and node heartbeat protocol ([loqa-core#6](https://github.com/loqalabs/loqa-core/issues/6))
+- [x] Local event store (SQLite + LiteFS) proof of concept ([loqa-core#7](https://github.com/loqalabs/loqa-core/issues/7))
+- [x] Observability stack deployment scripts (Grafana, Tempo, Prometheus) ([loqa-core#8](https://github.com/loqalabs/loqa-core/issues/8))
 
 ## Workstream B: Voice Pipeline ✅
-- [x] Integrate Whisper/faster-whisper wrapper with streaming API ([loqa-core#15](https://github.com/ambiware-labs/loqa-core/issues/15))
-- [x] LLM inference harness using llama.cpp/Ollama (quantized 3B + 7B) ([loqa-core#16](https://github.com/ambiware-labs/loqa-core/issues/16))
-- [x] TTS adapter for Kokoro with streaming playback ([loqa-core#17](https://github.com/ambiware-labs/loqa-core/issues/17))
-- [x] Session router orchestrating STT → LLM → TTS chain with per-hop QoS settings ([loqa-core#18](https://github.com/ambiware-labs/loqa-core/issues/18))
-- [x] Latency instrumentation surfacing `loqa.voice_latency_ms` ([loqa-core#19](https://github.com/ambiware-labs/loqa-core/issues/19))
+- [x] Integrate Whisper/faster-whisper wrapper with streaming API ([loqa-core#15](https://github.com/loqalabs/loqa-core/issues/15))
+- [x] LLM inference harness using llama.cpp/Ollama (quantized 3B + 7B) ([loqa-core#16](https://github.com/loqalabs/loqa-core/issues/16))
+- [x] TTS adapter for Kokoro with streaming playback ([loqa-core#17](https://github.com/loqalabs/loqa-core/issues/17))
+- [x] Session router orchestrating STT → LLM → TTS chain with per-hop QoS settings ([loqa-core#18](https://github.com/loqalabs/loqa-core/issues/18))
+- [x] Latency instrumentation surfacing `loqa.voice_latency_ms` ([loqa-core#19](https://github.com/loqalabs/loqa-core/issues/19))
 
 ## Workstream C: Skills & Plugins ✅
 - [x] Define `skill.yaml` schema and validation

--- a/roadmap/POST_MVP_BACKLOG.md
+++ b/roadmap/POST_MVP_BACKLOG.md
@@ -3,23 +3,23 @@
 This backlog captures the medium-term initiatives scheduled under the **Post-MVP Foundations** milestone. Items originate from the MASTER_SUMMARY synthesis and focus on resilience, adaptability, and sustainable operations.
 
 ## Memory & Context
-- [ ] Design path for privacy-preserving on-device vector memory feeding planner prompts ([loqa-meta#45](https://github.com/ambiware-labs/loqa-meta/issues/45))
+- [ ] Design path for privacy-preserving on-device vector memory feeding planner prompts ([loqa-meta#45](https://github.com/loqalabs/loqa-meta/issues/45))
 
 ## Intelligence & Routing
-- [ ] Define dynamic planner model selection between small deterministic and 7–8B fallbacks ([loqa-meta#46](https://github.com/ambiware-labs/loqa-meta/issues/46))
-- [ ] Map data/program requirements to fine-tune a Loqa-specific ≈3B planner ([loqa-meta#51](https://github.com/ambiware-labs/loqa-meta/issues/51))
+- [ ] Define dynamic planner model selection between small deterministic and 7–8B fallbacks ([loqa-meta#46](https://github.com/loqalabs/loqa-meta/issues/46))
+- [ ] Map data/program requirements to fine-tune a Loqa-specific ≈3B planner ([loqa-meta#51](https://github.com/loqalabs/loqa-meta/issues/51))
 
 ## Quality & Evaluation
-- [ ] Plan HomeBench-based regression suite with replayed voice logs ([loqa-meta#47](https://github.com/ambiware-labs/loqa-meta/issues/47))
+- [ ] Plan HomeBench-based regression suite with replayed voice logs ([loqa-meta#47](https://github.com/loqalabs/loqa-meta/issues/47))
 
 ## Platform & Cloud Strategy
-- [ ] Scope optional Loqa Cloud opt-in with encrypted sync guarantees ([loqa-meta#48](https://github.com/ambiware-labs/loqa-meta/issues/48))
+- [ ] Scope optional Loqa Cloud opt-in with encrypted sync guarantees ([loqa-meta#48](https://github.com/loqalabs/loqa-meta/issues/48))
 
 ## Deployment & Ops
-- [ ] Produce K3s/MicroK8s deployment profile for Jetson/Pi clusters ([loqa-meta#49](https://github.com/ambiware-labs/loqa-meta/issues/49))
+- [ ] Produce K3s/MicroK8s deployment profile for Jetson/Pi clusters ([loqa-meta#49](https://github.com/loqalabs/loqa-meta/issues/49))
 
 ## Developer Experience
-- [ ] Investigate declarative pipeline DSL for composing sensor→reasoner→actuator flows ([loqa-meta#50](https://github.com/ambiware-labs/loqa-meta/issues/50))
+- [ ] Investigate declarative pipeline DSL for composing sensor→reasoner→actuator flows ([loqa-meta#50](https://github.com/loqalabs/loqa-meta/issues/50))
 
 ## Cadence & Milestone Exit
 - Review progress monthly alongside MVP maintenance board.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -133,9 +133,9 @@ Major features go through the RFC process. Current RFCs:
 
 ## Get Involved
 
-- Star the [repository](https://github.com/ambiware-labs/loqa-core)
-- Join [discussions](https://github.com/ambiware-labs/loqa-meta/discussions)
-- Follow [@ambiware-labs](https://github.com/ambiware-labs)
+- Star the [repository](https://github.com/loqalabs/loqa-core)
+- Join [discussions](https://github.com/loqalabs/loqa-meta/discussions)
+- Follow [@loqalabs](https://github.com/loqalabs)
 - Email: hello@ambiware.ai
 
 ---

--- a/roadmap/workstream-e/internal_dogfooding_plan.md
+++ b/roadmap/workstream-e/internal_dogfooding_plan.md
@@ -1,6 +1,6 @@
 # Workstream E – Internal Dogfooding Cluster Plan
 
-Issue reference: [loqa-meta#14](https://github.com/ambiware-labs/loqa-meta/issues/14)
+Issue reference: [loqa-meta#14](https://github.com/loqalabs/loqa-meta/issues/14)
 
 ## Objectives
 - Exercise nightly builds in a realistic, always-on environment prior to external releases.

--- a/roadmap/workstream-f/value_add_roadmap.md
+++ b/roadmap/workstream-f/value_add_roadmap.md
@@ -1,6 +1,6 @@
 # Workstream F – Value-Add Offerings Roadmap
 
-Issue reference: [loqa-meta#28](https://github.com/ambiware-labs/loqa-meta/issues/28)
+Issue reference: [loqa-meta#28](https://github.com/loqalabs/loqa-meta/issues/28)
 
 ## Objectives
 - Generate sustainable revenue without compromising Loqa’s local-first, open-core promise.
@@ -33,7 +33,7 @@ Issue reference: [loqa-meta#28](https://github.com/ambiware-labs/loqa-meta/issue
 
 4. **Hardware Starter Kits**
    - Pre-imaged Mac mini / Pi kits with skills installed, nice enclosure.
-   - Partnerships with hardware vendors (see [loqa-meta#29](https://github.com/ambiware-labs/loqa-meta/issues/29)).
+   - Partnerships with hardware vendors (see [loqa-meta#29](https://github.com/loqalabs/loqa-meta/issues/29)).
 
 ## Experiments & Validation
 | Experiment | Metric | Status |

--- a/studio/README.md
+++ b/studio/README.md
@@ -9,7 +9,7 @@ Loqa Studio accepts extensions that respect Loqa’s local-first principles:
 | Category | Examples | Notes |
 | --- | --- | --- |
 | Persona Packs | Custom assistant personalities, domain-specific prompts, voice tuning bundles | Must declare data sources and safety constraints. |
-| Premium Skills / Add-ons | Advanced automations, integrations, analytics dashboards | Built against the [skills spec](https://github.com/ambiware-labs/loqa-core/blob/main/docs/skills/SPEC.md); may target WASM or exec runtimes. |
+| Premium Skills / Add-ons | Advanced automations, integrations, analytics dashboards | Built against the [skills spec](https://github.com/loqalabs/loqa-core/blob/main/docs/skills/SPEC.md); may target WASM or exec runtimes. |
 | Loqa Cloud Integrations | Optional encrypted sync, shared memory spaces, multi-device orchestration | Must use end-to-end encryption and pass security review. |
 | Training & Courses | Workshops, onboarding curricula, certification tracks | Provide syllabus outline and delivery format. |
 | Pre-flashed Hardware Kits | Partner-built kits ready to plug into Loqa | Coordinate with Ambiware hardware program (see Workstream F roadmap).


### PR DESCRIPTION
Updates all references from ambiware-labs to loqalabs as part of brand migration.

Migration Phase: Phase 2.3 - Repository Updates